### PR TITLE
Fix ubuntu booting

### DIFF
--- a/distro-profiles.json
+++ b/distro-profiles.json
@@ -8,9 +8,8 @@
       "filename_patterns": ["ubuntu", "xubuntu", "kubuntu", "lubuntu", "edubuntu", "ubuntumate", "ubuntustudio", "budgie", "noble", "jammy"],
       "kernel_paths": ["/casper/vmlinuz", "/casper/vmlinuz.efi"],
       "initrd_paths": ["/casper/initrd", "/casper/initrd.lz", "/casper/initrd.gz"],
-      "squashfs_paths": [""],
+      "squashfs_paths": ["/casper/filesystem.squashfs"],
       "default_boot_params": "boot=casper initrd=initrd ip=dhcp url={{BASE_URL}}/isos/{{FILENAME}}",
-      "boot_params_with_squashfs": "boot=casper initrd=initrd ip=dhcp url={{BASE_URL}}/isos/{{FILENAME}}",
       "auto_install_type": "autoinstall"
     },
     {

--- a/distro-profiles.json
+++ b/distro-profiles.json
@@ -8,9 +8,9 @@
       "filename_patterns": ["ubuntu", "xubuntu", "kubuntu", "lubuntu", "edubuntu", "ubuntumate", "ubuntustudio", "budgie", "noble", "jammy"],
       "kernel_paths": ["/casper/vmlinuz", "/casper/vmlinuz.efi"],
       "initrd_paths": ["/casper/initrd", "/casper/initrd.lz", "/casper/initrd.gz"],
-      "squashfs_paths": ["/casper/filesystem.squashfs"],
+      "squashfs_paths": [""],
       "default_boot_params": "boot=casper initrd=initrd ip=dhcp url={{BASE_URL}}/isos/{{FILENAME}}",
-      "boot_params_with_squashfs": "boot=casper initrd=initrd ip=dhcp fetch={{SQUASHFS}}",
+      "boot_params_with_squashfs": "boot=casper initrd=initrd ip=dhcp url={{BASE_URL}}/isos/{{FILENAME}}",
       "auto_install_type": "autoinstall"
     },
     {


### PR DESCRIPTION
Fix ubuntu booting.
Ubuntu does not support squashfs booting, url= must be the iso file.
Tested this with multiple ubuntu based distros:

* Avira Rescue System, 
* Foxclone
* Rescuzilla
* Ubuntu 24.04
* Mint 22.2

After the change, they are booting now.

@garybowers not so deep in the code, is ok, to just remove `boot_params_with_squashfs` to force use `default_boot_params`? I have changed my boot arguments manually and tested the above distros.