### PR TITLE
fix(docker): add `bsdtar` for extraction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ COPY --from=builder /out/ /
 FROM debian:trixie-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    wimtools samba ca-certificates \
+    wimtools samba ca-certificates bsdtar \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /out/bootimus /bootimus


### PR DESCRIPTION
Some images (Ubuntu Server) require `bsdtar` for extraction, and fail as it is currently not installed. This adds it to the image.