### PR TITLE
fix(docker): replace `bsdtar` with actual `libarchivetools`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ COPY --from=builder /out/ /
 FROM debian:trixie-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    wimtools samba ca-certificates bsdtar \
+    wimtools samba ca-certificates libarchive-tools \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /out/bootimus /bootimus


### PR DESCRIPTION
Sorry, rookie error on my part! I looked up the package name but didn't actually test. This is the actual package name that provides the `bsdtar` binary (and support other archive formats that might crop up).

---

It might be good to get some CI set up to stop idiots like me making changes like that which don't actually compile. If that sounds useful let me know and I can add a docker build action. 