### PR TITLE
Updated distro-profiles.json

### DIFF
--- a/distro-profiles.json
+++ b/distro-profiles.json
@@ -197,11 +197,11 @@
       "mirrors": [
         {"region": "Global (Auto-redirect)", "base": "https://download.fedoraproject.org/pub/fedora/linux/releases"},
         {"region": "UK (Mythic Beasts)", "base": "https://mirrors.mythic-beasts.com/fedora-pub/fedora/linux/releases"},
-        {"region": "DE (Hetzner)", "base": "https://ftp.hetzner.com/fedora/linux/releases"}
+        {"region": "DE (FAU)", "base": "https://ftp.fau.de/fedora/linux/releases"}
       ],
       "releases": [
-        {"label": "41 Workstation (x86_64)", "path": "/41/Workstation/x86_64/iso/Fedora-Workstation-Live-x86_64-41-1.4.iso"},
-        {"label": "41 Server DVD (x86_64)", "path": "/41/Server/x86_64/iso/Fedora-Server-dvd-x86_64-41-1.4.iso"}
+        {"label": "44 Workstation (x86_64)", "path": "/44/Workstation/x86_64/iso/Fedora-Workstation-Live-x86_64-44-1.7.iso"},
+        {"label": "44 Server DVD (x86_64)", "path": "/44/Server/x86_64/iso/Fedora-Server-dvd-x86_64-44-1.7.iso"}
       ]
     },
     {
@@ -279,7 +279,16 @@
       "squashfs_paths": [],
       "default_boot_params": "install={{BASE_URL}}/boot/{{CACHE_DIR}}/iso/",
       "auto_install_type": "",
-      "boot_method": "kernel"
+      "boot_method": "kernel",
+      "mirrors": [
+	{"region": "DE (RTWH Aachen)", "base": "https://ftp.halifax.rwth-aachen.de/opensuse"}
+      ],
+      "releases": [
+        {"label": "Tumbleweed DVD (64-bit)", "path": "/tumbleweed/iso/openSUSE-Tumbleweed-DVD-x86_64-Current.iso"},
+        {"label": "Tumbleweed NET (64-bit)", "path": "/tumbleweed/iso/openSUSE-Tumbleweed-NET-x86_64-Current.iso"},
+	{"label": "Leap 16.1 Online Install (64-bit)", "path": "/distribution/leap/16.1/iso/Leap-16.1-online-installer-x86_64.install.iso"},
+	{"label": "Leap 16.1 Offline Install (64-bit)", "path": "/distribution/leap/16.1/iso/Leap-16.1-offline-installer-x86_64.install.iso"}
+	]
     },
     {
       "id": "alpine",

--- a/internal/profiles/distro-profiles.json
+++ b/internal/profiles/distro-profiles.json
@@ -15,12 +15,13 @@
       "mirrors": [
         {"region": "Global (Canonical)", "base": "https://releases.ubuntu.com"},
         {"region": "UK (Bytemark)", "base": "https://mirror.bytemark.co.uk/ubuntu-releases"},
-        {"region": "DE (GWDG)", "base": "https://ftp.gwdg.de/pub/linux/ubuntu-releases"}
+        {"region": "DE (Uni Erlangen)", "base": "https://ftp.uni-erlangen.de/mirrors/ubuntu-releases"}
       ],
       "releases": [
-        {"label": "24.04 LTS Desktop (amd64)", "path": "/24.04.3/ubuntu-24.04.3-desktop-amd64.iso"},
-        {"label": "24.04 LTS Server (amd64)", "path": "/24.04.3/ubuntu-24.04.3-live-server-amd64.iso"},
-        {"label": "22.04 LTS Desktop (amd64)", "path": "/22.04.5/ubuntu-22.04.5-desktop-amd64.iso"}
+        {"label": "26.04 LTS Desktop (amd64)", "path": "/26.04/ubuntu-26.04-desktop-amd64.iso"},
+        {"label": "26.04 LTS Server (amd64)", "path": "/26.04/ubuntu-26.04-live-server-amd64.iso"},
+        {"label": "24.04 LTS Desktop (amd64)", "path": "/24.04.4/ubuntu-24.04.4-desktop-amd64.iso"},
+	{"label": "24.04 LTS Server (amd64)", "path": "/24.04.4/ubuntu-24.04.4-live-server-amd64.iso"}
       ]
     },
     {
@@ -35,12 +36,13 @@
       "auto_install_type": "",
       "boot_method": "kernel",
       "mirrors": [
-        {"region": "UK (Universiry of Kent Mirrorservice)", "base": "https://mirrorservice.org/sites/www.linuxmint.com/pub/linuxmint.com"}
+        {"region": "UK (Universiry of Kent Mirrorservice)", "base": "https://mirrorservice.org/sites/www.linuxmint.com/pub/linuxmint.com"},
+	{"region": "DE (GWDG)", "base": "https://ftp5.gwdg.de/pub/linux/debian/mint"}
       ],
       "releases": [
-        {"label": "22.3 Cinnamon (64-bit)", "path": "/stable/22.1/linuxmint-22.3-cinnamon-64bit.iso"},
-        {"label": "22.3 MATE (64-bit)", "path": "/stable/22.1/linuxmint-22.3-mate-64bit.iso"},
-        {"label": "22.3 XFCE (64-bit)", "path": "/stable/22.1/linuxmint-22.3-xfce-64bit.iso"}
+        {"label": "22.3 Cinnamon (64-bit)", "path": "/stable/22.3/linuxmint-22.3-cinnamon-64bit.iso"},
+        {"label": "22.3 MATE (64-bit)", "path": "/stable/22.3/linuxmint-22.3-mate-64bit.iso"},
+        {"label": "22.3 XFCE (64-bit)", "path": "/stable/22.3/linuxmint-22.3-xfce-64bit.iso"}
       ]
     },
     {
@@ -109,8 +111,8 @@
         {"region": "DE (GWDG)", "base": "https://ftp.gwdg.de/debian-cd/current/amd64"}
       ],
       "releases": [
-        {"label": "13 (Trixie) DVD-1 (amd64)", "path": "/iso-dvd/debian-13.4.0-amd64-DVD-1.iso"},
-        {"label": "13 (Trixie) Netinst (amd64)", "path": "/iso-cd/debian-13.4.0-amd64-netinst.iso"}
+        {"label": "13 (Trixie) DVD-1 (amd64)", "path": "/iso-dvd/debian-13.5.0-amd64-DVD-1.iso"},
+        {"label": "13 (Trixie) Netinst (amd64)", "path": "/iso-cd/debian-13.5.0-amd64-netinst.iso"}
       ]
     },
     {
@@ -195,11 +197,11 @@
       "mirrors": [
         {"region": "Global (Auto-redirect)", "base": "https://download.fedoraproject.org/pub/fedora/linux/releases"},
         {"region": "UK (Mythic Beasts)", "base": "https://mirrors.mythic-beasts.com/fedora-pub/fedora/linux/releases"},
-        {"region": "DE (Hetzner)", "base": "https://ftp.hetzner.com/fedora/linux/releases"}
+        {"region": "DE (FAU)", "base": "https://ftp.fau.de/fedora/linux/releases"}
       ],
       "releases": [
-        {"label": "41 Workstation (x86_64)", "path": "/41/Workstation/x86_64/iso/Fedora-Workstation-Live-x86_64-41-1.4.iso"},
-        {"label": "41 Server DVD (x86_64)", "path": "/41/Server/x86_64/iso/Fedora-Server-dvd-x86_64-41-1.4.iso"}
+        {"label": "44 Workstation (x86_64)", "path": "/44/Workstation/x86_64/iso/Fedora-Workstation-Live-x86_64-44-1.7.iso"},
+        {"label": "44 Server DVD (x86_64)", "path": "/44/Server/x86_64/iso/Fedora-Server-dvd-x86_64-44-1.7.iso"}
       ]
     },
     {
@@ -277,7 +279,16 @@
       "squashfs_paths": [],
       "default_boot_params": "install={{BASE_URL}}/boot/{{CACHE_DIR}}/iso/",
       "auto_install_type": "",
-      "boot_method": "kernel"
+      "boot_method": "kernel",
+      "mirrors": [
+	{"region": "DE (RTWH Aachen)", "base": "https://ftp.halifax.rwth-aachen.de/opensuse"}
+      ],
+      "releases": [
+        {"label": "Tumbleweed DVD (64-bit)", "path": "/tumbleweed/iso/openSUSE-Tumbleweed-DVD-x86_64-Current.iso"},
+        {"label": "Tumbleweed NET (64-bit)", "path": "/tumbleweed/iso/openSUSE-Tumbleweed-NET-x86_64-Current.iso"},
+	{"label": "Leap 16.1 Online Install (64-bit)", "path": "/distribution/leap/16.1/iso/Leap-16.1-online-installer-x86_64.install.iso"},
+	{"label": "Leap 16.1 Offline Install (64-bit)", "path": "/distribution/leap/16.1/iso/Leap-16.1-offline-installer-x86_64.install.iso"}
+	]
     },
     {
       "id": "alpine",


### PR DESCRIPTION
Hi, in addition to my Previous PR (#75) i did the following modifications to distro-profiles.json:

### Updated Fedora Download Links to 44
For this the following was done: 
- Change German Mirror from Hetzner to FAU
- Removed Fedora 41 Download URLs and added the URLs for Fedora 44 instead

### Added OpenSuse Tumbleweed and Leap 16.1 Download Links
For this the following was done: 
- Created Entry for German Mirror (RTWH Aachen) 
- Added Download URLs for Leap 16.1 (On and Offline Install) as well as Tumbleweed DVD and NET ISO Download URLs

and some housekeeping by syncing changes to distro-profiles.json in /internal/profiles/