### PR TITLE
Add MAC substition in kernel boot line

### DIFF
--- a/internal/server/menu.go
+++ b/internal/server/menu.go
@@ -338,6 +338,7 @@ func (mb *MenuBuilder) resolveBootParams(img *models.Image, baseURL, encodedFile
 	params = strings.ReplaceAll(params, "{{BASE_URL}}", baseURL)
 	params = strings.ReplaceAll(params, "{{CACHE_DIR}}", cacheDir)
 	params = strings.ReplaceAll(params, "{{FILENAME}}", encodedFilename)
+	params = strings.ReplaceAll(params, "{{MAC}}", mb.macAddress)
 	if img.SquashfsPath != "" {
 		params = strings.ReplaceAll(params, "{{SQUASHFS}}", fmt.Sprintf("%s/boot/%s/%s", baseURL, cacheDir, img.SquashfsPath))
 	}


### PR DESCRIPTION
- Need to pass MAC address to autoinstall/image.iso?mac=xyz to retrieve client specific information (EX, CLIENT_NAME). As-is it won't find the client as the MAC isn't passed along, causing the replacement to return an empty value

Fixes #85 