### PR TITLE
Fix Secure Boot bootloader-set wiring and Windows 24H2+ netboot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,20 @@ RUN cp /out/bootimus-${TARGETOS}-${TARGETARCH} /out/bootimus
 FROM scratch AS binaries
 COPY --from=builder /out/ /
 
+# Stage: assemble the zero-enrollment Secure Boot set (Microsoft-signed shim
+# + iPXE binaries signed by the iPXE Secure Boot CA) at build time, so the
+# image ships it ready to seed into the data volume.
+FROM debian:trixie-slim AS secureboot-official
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+COPY scripts/build-secureboot-official-set.sh scripts/
+COPY bootloaders/default/undionly.kpxe bootloaders/default/
+RUN bash scripts/build-secureboot-official-set.sh
+
 # Stage 2: Runtime
 FROM debian:trixie-slim
 
@@ -34,11 +48,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /out/bootimus /bootimus
+COPY --from=secureboot-official /src/bootloaders/secureboot-official /usr/share/bootimus/secureboot-official
+COPY scripts/docker-entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
 EXPOSE 69/udp 8080/tcp 8081/tcp 10809/tcp 445/tcp
 
 USER root
 
 VOLUME [ "/data" ]
-ENTRYPOINT ["/bootimus"]
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["serve"]

--- a/bootloaders/manifest.go
+++ b/bootloaders/manifest.go
@@ -1,0 +1,36 @@
+package bootloaders
+
+import (
+	"encoding/json"
+	"path"
+)
+
+type Manifest struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	ShimVersion string `json:"shim_version,omitempty"`
+	Bootfiles   struct {
+		BIOS  string `json:"bios"`
+		UEFI  string `json:"uefi"`
+		ARM64 string `json:"arm64"`
+	} `json:"bootfiles"`
+}
+
+func ParseManifest(data []byte) (*Manifest, error) {
+	var m Manifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, err
+	}
+	return &m, nil
+}
+
+func LoadManifest(setName string) (*Manifest, error) {
+	if setName == "" {
+		setName = DefaultSet
+	}
+	data, err := Bootloaders.ReadFile(path.Join(setName, "manifest.json"))
+	if err != nil {
+		return nil, err
+	}
+	return ParseManifest(data)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"strings"
 
+	"bootimus/internal/proxydhcp"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -66,9 +68,9 @@ func init() {
 	rootCmd.PersistentFlags().Bool("disable-remote-profiles", false, "Disable remote distro profile updates")
 
 	rootCmd.PersistentFlags().Bool("proxy-dhcp", false, "Enable in-process proxyDHCP server (answers PXE requests without handing out IPs; requires root or CAP_NET_BIND_SERVICE)")
-	rootCmd.PersistentFlags().String("proxy-dhcp-bootfile-bios", "undionly.kpxe", "Bootfile advertised to legacy BIOS PXE clients")
-	rootCmd.PersistentFlags().String("proxy-dhcp-bootfile-uefi", "bootimus.efi", "Bootfile advertised to UEFI x64 PXE clients")
-	rootCmd.PersistentFlags().String("proxy-dhcp-bootfile-arm64", "bootimus-arm64.efi", "Bootfile advertised to UEFI ARM64 PXE clients")
+	rootCmd.PersistentFlags().String("proxy-dhcp-bootfile-bios", proxydhcp.DefaultBootfileBIOS, "Bootfile advertised to legacy BIOS PXE clients (default follows the active bootloader set's manifest)")
+	rootCmd.PersistentFlags().String("proxy-dhcp-bootfile-uefi", proxydhcp.DefaultBootfileUEFI, "Bootfile advertised to UEFI x64 PXE clients (default follows the active bootloader set's manifest)")
+	rootCmd.PersistentFlags().String("proxy-dhcp-bootfile-arm64", proxydhcp.DefaultBootfileARM64, "Bootfile advertised to UEFI ARM64 PXE clients (default follows the active bootloader set's manifest)")
 
 	rootCmd.PersistentFlags().Bool("windows-smb", false, "Enable Samba share for unattended Windows PXE installs (requires smbd in PATH)")
 	rootCmd.PersistentFlags().Int("windows-smb-port", 445, "SMB port (Windows 'net use' always uses 445; override only for testing)")

--- a/distro-profiles.json
+++ b/distro-profiles.json
@@ -476,7 +476,7 @@
       "kernel_paths": ["/sources/boot.wim"],
       "initrd_paths": [],
       "squashfs_paths": [],
-      "default_boot_params": "rawbcd",
+      "default_boot_params": "",
       "auto_install_type": "autounattend",
       "boot_method": "kernel"
     },

--- a/internal/admin/handlers.go
+++ b/internal/admin/handlers.go
@@ -190,6 +190,17 @@ func buildStartnetScript(serverAddr, shareName string, smbPort, httpPort int, is
 
 	base := fmt.Sprintf(`@echo off
 wpeinit
+rem Windows 11 24H2+ WinPE ships with insecure guest auth disabled and SMB
+rem signing required; guest sessions cannot sign, so mapping the read-only
+rem guest share fails with access denied. Re-enable guest SMB for this
+rem WinPE session only (never touches the installed OS). Must be set before
+rem the Workstation service starts, which is when the parameters are read.
+reg add HKLM\SYSTEM\CurrentControlSet\Services\LanmanWorkstation\Parameters /v AllowInsecureGuestAuth /t REG_DWORD /d 1 /f >nul 2>&1
+reg add HKLM\SYSTEM\CurrentControlSet\Services\LanmanWorkstation\Parameters /v RequireSecuritySignature /t REG_DWORD /d 0 /f >nul 2>&1
+rem Start the SMB client now so the redirector finishes binding to the NIC
+rem while we wait for the network below — started any later, the first
+rem mapping attempts fail with transient "System error 53".
+net start Workstation >nul 2>&1
 echo Acquiring DHCP lease...
 ipconfig /renew >nul 2>&1
 
@@ -211,14 +222,15 @@ exit /b 1
 :netready
 
 echo Connecting to bootimus installation source...
-rem Kick the SMB client stack — net use otherwise triggers lazy init and races wpeinit.
-net start Workstation >nul 2>&1
 set /a TRIES=0
 :mapshare
-net use Z: \\%s\%s /persistent:no >nul
+rem Expected to fail with "System error 53" for the first few tries while the
+rem SMB client stack and the server's 445 path come up — the loop handles it.
+net use Z: \\%s\%s /persistent:no >nul 2>&1
 if not errorlevel 1 goto mapped
 set /a TRIES+=1
 if %%TRIES%% geq 30 goto mapfail
+echo Still trying to connect (%%TRIES%%/30), please wait...
 ping 127.0.0.1 -n 4 >nul 2>&1
 goto mapshare
 :mapfail

--- a/internal/profiles/distro-profiles.json
+++ b/internal/profiles/distro-profiles.json
@@ -474,7 +474,7 @@
       "kernel_paths": ["/sources/boot.wim"],
       "initrd_paths": [],
       "squashfs_paths": [],
-      "default_boot_params": "rawbcd",
+      "default_boot_params": "",
       "auto_install_type": "autounattend",
       "boot_method": "kernel"
     },

--- a/internal/proxydhcp/proxydhcp.go
+++ b/internal/proxydhcp/proxydhcp.go
@@ -13,11 +13,21 @@ import (
 	"github.com/insomniacslk/dhcp/iana"
 )
 
+const (
+	DefaultBootfileBIOS  = "undionly.kpxe"
+	DefaultBootfileUEFI  = "bootimus.efi"
+	DefaultBootfileARM64 = "bootimus-arm64.efi"
+)
+
 type Config struct {
 	ServerIP      net.IP
 	BootfileBIOS  string
 	BootfileUEFI  string
 	BootfileARM64 string
+	// Bootfiles, when set, is consulted on every request; any non-empty value
+	// it returns overrides the static Bootfile* fields. This lets the server
+	// switch bootloader sets at runtime without restarting proxyDHCP.
+	Bootfiles func() (bios, uefi, arm64 string)
 }
 
 type Server struct {
@@ -37,13 +47,13 @@ func NewServer(cfg Config) (*Server, error) {
 		cfg.ServerIP = ip
 	}
 	if cfg.BootfileBIOS == "" {
-		cfg.BootfileBIOS = "undionly.kpxe"
+		cfg.BootfileBIOS = DefaultBootfileBIOS
 	}
 	if cfg.BootfileUEFI == "" {
-		cfg.BootfileUEFI = "bootimus.efi"
+		cfg.BootfileUEFI = DefaultBootfileUEFI
 	}
 	if cfg.BootfileARM64 == "" {
-		cfg.BootfileARM64 = "bootimus-arm64.efi"
+		cfg.BootfileARM64 = DefaultBootfileARM64
 	}
 	return &Server{cfg: cfg, done: make(chan struct{})}, nil
 }
@@ -66,8 +76,9 @@ func (s *Server) Start() error {
 	}
 	s.conn4011 = conn4011
 
+	bios, uefi, arm64 := s.effectiveBootfiles()
 	log.Printf("proxyDHCP: listening on UDP/67 + UDP/4011, advertising next-server=%s (BIOS=%s, UEFI=%s, ARM64=%s)",
-		s.cfg.ServerIP, s.cfg.BootfileBIOS, s.cfg.BootfileUEFI, s.cfg.BootfileARM64)
+		s.cfg.ServerIP, bios, uefi, arm64)
 
 	s.wg.Add(2)
 	go s.loop(conn, true)
@@ -172,14 +183,32 @@ func pxeVendorOptions() []byte {
 	}
 }
 
+func (s *Server) effectiveBootfiles() (bios, uefi, arm64 string) {
+	bios, uefi, arm64 = s.cfg.BootfileBIOS, s.cfg.BootfileUEFI, s.cfg.BootfileARM64
+	if s.cfg.Bootfiles != nil {
+		overrideBIOS, overrideUEFI, overrideARM64 := s.cfg.Bootfiles()
+		if overrideBIOS != "" {
+			bios = overrideBIOS
+		}
+		if overrideUEFI != "" {
+			uefi = overrideUEFI
+		}
+		if overrideARM64 != "" {
+			arm64 = overrideARM64
+		}
+	}
+	return bios, uefi, arm64
+}
+
 func (s *Server) bootfileFor(req *dhcpv4.DHCPv4) string {
+	bios, uefi, arm64 := s.effectiveBootfiles()
 	switch clientArch(req) {
 	case iana.EFI_IA32, iana.EFI_X86_64, iana.EFI_BC:
-		return s.cfg.BootfileUEFI
+		return uefi
 	case iana.EFI_ARM64:
-		return s.cfg.BootfileARM64
+		return arm64
 	default:
-		return s.cfg.BootfileBIOS
+		return bios
 	}
 }
 

--- a/internal/server/menu.go
+++ b/internal/server/menu.go
@@ -307,10 +307,19 @@ func (mb *MenuBuilder) buildKernelBootSection(img *models.Image, encodedFilename
 
 	switch img.Distro {
 	case "windows", "windows7":
+		// wimboot's command line only takes its own flags — kernel parameters
+		// and the generic iso-url fallback are meaningless here and make it
+		// abort with "Unrecognised argument" (the UI locks the field for the
+		// same reason). Only the legacy windows7 profile passes flags (rawbcd).
+		wimbootArgs := ""
+		if img.Distro == "windows7" {
+			wimbootArgs = bootParams
+		}
 		sb.WriteString("echo Loading Windows boot files via wimboot...\n")
-		sb.WriteString(fmt.Sprintf("kernel %s/wimboot%s\n", baseURL, bootParams))
-		sb.WriteString(fmt.Sprintf("initrd %s/boot/%s/iso/boot/bcd BCD || initrd %s/boot/%s/iso/BOOT/BCD BCD\n", baseURL, cacheDir, baseURL, cacheDir))
-		sb.WriteString(fmt.Sprintf("initrd %s/boot/%s/iso/boot/boot.sdi boot.sdi || initrd %s/boot/%s/iso/BOOT/BOOT.SDI boot.sdi\n", baseURL, cacheDir, baseURL, cacheDir))
+		sb.WriteString(fmt.Sprintf("kernel %s/wimboot%s\n", baseURL, wimbootArgs))
+		// Ship only boot.wim and let wimboot synthesize the ramdisk BCD +
+		// boot.sdi (the documented minimal setup). Feeding the ISO's DVD BCD
+		// hangs 24H2/25H2 media on a black screen after the loading bar.
 		sb.WriteString(fmt.Sprintf("initrd %s/boot/%s/iso/sources/boot.wim boot.wim || initrd %s/boot/%s/iso/SOURCES/BOOT.WIM boot.wim\n", baseURL, cacheDir, baseURL, cacheDir))
 		sb.WriteString("boot || goto failed\n")
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -356,8 +356,59 @@ func (s *Server) GetActiveBootloaderSet() string {
 
 func (s *Server) SetActiveBootloaderSet(name string) {
 	s.activeBootloaderSetMu.Lock()
-	defer s.activeBootloaderSetMu.Unlock()
 	s.activeBootloaderSet = name
+	s.activeBootloaderSetMu.Unlock()
+
+	display := name
+	if display == "" {
+		display = bootloaders.DefaultSet
+	}
+	bios, uefi, arm64 := s.proxyDHCPBootfiles()
+	log.Printf("Bootloader set %q active: PXE bootfiles BIOS=%s UEFI=%s ARM64=%s", display, bios, uefi, arm64)
+}
+
+// activeSetManifest loads manifest.json for the active bootloader set — from
+// the on-disk set directory when present, otherwise from the embedded sets.
+func (s *Server) activeSetManifest() *bootloaders.Manifest {
+	setName := s.GetActiveBootloaderSet()
+	if setName == "" {
+		setName = bootloaders.DefaultSet
+	}
+	if s.config.BootDir != "" {
+		diskPath := filepath.Join(s.config.BootDir, setName, "manifest.json")
+		if data, err := os.ReadFile(diskPath); err == nil {
+			if m, err := bootloaders.ParseManifest(data); err == nil {
+				return m
+			}
+		}
+	}
+	m, err := bootloaders.LoadManifest(setName)
+	if err != nil {
+		return nil
+	}
+	return m
+}
+
+// proxyDHCPBootfiles returns the bootfile names proxyDHCP should advertise.
+// Precedence: explicitly configured value (differs from the compiled default)
+// > active bootloader set manifest > compiled default. Evaluated per DHCP
+// request, so switching sets takes effect without a restart.
+func (s *Server) proxyDHCPBootfiles() (bios, uefi, arm64 string) {
+	bios = s.config.ProxyDHCPBootfileBIOS
+	uefi = s.config.ProxyDHCPBootfileUEFI
+	arm64 = s.config.ProxyDHCPBootfileARM
+	if m := s.activeSetManifest(); m != nil {
+		if (bios == "" || bios == proxydhcp.DefaultBootfileBIOS) && m.Bootfiles.BIOS != "" {
+			bios = m.Bootfiles.BIOS
+		}
+		if (uefi == "" || uefi == proxydhcp.DefaultBootfileUEFI) && m.Bootfiles.UEFI != "" {
+			uefi = m.Bootfiles.UEFI
+		}
+		if (arm64 == "" || arm64 == proxydhcp.DefaultBootfileARM64) && m.Bootfiles.ARM64 != "" {
+			arm64 = m.Bootfiles.ARM64
+		}
+	}
+	return bios, uefi, arm64
 }
 
 func (s *Server) resolveBootloaderFile(filename string) string {
@@ -540,6 +591,7 @@ func (s *Server) Start() error {
 			BootfileBIOS:  s.config.ProxyDHCPBootfileBIOS,
 			BootfileUEFI:  s.config.ProxyDHCPBootfileUEFI,
 			BootfileARM64: s.config.ProxyDHCPBootfileARM,
+			Bootfiles:     s.proxyDHCPBootfiles,
 		})
 		if err != nil {
 			log.Printf("proxyDHCP: failed to construct server: %v", err)
@@ -1768,10 +1820,6 @@ echo Auto-install enabled for this image
 {{if eq $img.Distro "windows"}}
 echo Loading Windows boot files via wimboot...
 kernel http://{{$.ServerAddr}}:{{$.HTTPPort}}/wimboot
-initrd http://{{$.ServerAddr}}:{{$.HTTPPort}}/boot/{{$img.CacheDir}}/bootmgfw.efi bootmgfw.efi
-initrd http://{{$.ServerAddr}}:{{$.HTTPPort}}/boot/{{$img.CacheDir}}/bootx64.efi bootx64.efi
-initrd http://{{$.ServerAddr}}:{{$.HTTPPort}}/boot/{{$img.CacheDir}}/bcd BCD
-initrd http://{{$.ServerAddr}}:{{$.HTTPPort}}/boot/{{$img.CacheDir}}/boot.sdi boot.sdi
 initrd http://{{$.ServerAddr}}:{{$.HTTPPort}}/boot/{{$img.CacheDir}}/boot.wim boot.wim
 {{if $img.InstallWimPath}}initrd --name {{$img.InstallBasename}} http://{{$.ServerAddr}}:{{$.HTTPPort}}/boot/{{$img.CacheDir}}/{{$img.InstallBasename}}
 {{end}}boot || goto failed

--- a/internal/smb/manager.go
+++ b/internal/smb/manager.go
@@ -194,6 +194,11 @@ func (m *Manager) writeConfig() error {
    path = %s
    read only = yes
    guest ok = yes
+   # Guest maps to "nobody" (uid 65534), which NFS-backed data dirs commonly
+   # reject (root squash / export rules only trust specific UIDs). The
+   # bootimus process already reads these files as root, so let smbd do the
+   # same. Shares are read-only, so this only widens reads.
+   force user = root
    browseable = yes
 
 `, name, path)

--- a/scripts/build-secureboot-official-set.sh
+++ b/scripts/build-secureboot-official-set.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+set -euo pipefail
+
+# Builds the "secureboot-official" bootloader set — the zero-enrollment
+# UEFI Secure Boot chain:
+#   - Microsoft-signed shim taken from the SAME iPXE release archive as the
+#     iPXE binaries it verifies (shim build and signing certs must be a
+#     matched pair — mixing a standalone ipxe/shim release with a different
+#     iPXE release's signed binaries can fail verification)
+#   - Stock iPXE binaries signed by the iPXE project's own Secure Boot CA
+#   - Official wimboot release binary (Microsoft-signed) for Windows images
+#
+# Nothing is signed locally and no per-machine cert enrollment is needed:
+# firmware trusts the Microsoft-signed shim, shim trusts the iPXE Secure Boot
+# CA baked into it as vendor certificate.
+#
+# Tradeoffs vs the "secureboot" set (scripts/build-secureboot-set.sh):
+#   - The official iPXE binaries do NOT contain the Bootimus embed.ipxe script.
+#     Discovery relies on iPXE (>= v2.0) automatically fetching autoexec.ipxe
+#     over TFTP, which Bootimus generates dynamically per client.
+#   - iPXE v2.0.0 has a known keyboard regression in interactive menus (the
+#     reason the self-built sets pin v1.21.1). Test menu input on real
+#     hardware; prefer the newest v2.0.x point release via IPXE_VERSION.
+#   - NBD/NFS image boots still fail under Secure Boot: the Bootimus boot
+#     environment kernel is unsigned and no public CA will sign it. Those
+#     methods need the "secureboot" set + cert enrollment, or Secure Boot off.
+#
+# Requirements on the host: curl, tar
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BOOTLOADERS_DEFAULT="$ROOT_DIR/bootloaders/default"
+OUT_DIR="$ROOT_DIR/bootloaders/secureboot-official"
+
+# First iPXE release with official Secure Boot signed binaries is v2.0.0.
+IPXE_VERSION="${IPXE_VERSION:-v2.0.0}"
+IPXE_RELEASE_BASE="https://github.com/ipxe/ipxe/releases/download/${IPXE_VERSION}"
+WIMBOOT_VERSION="${WIMBOOT_VERSION:-v2.9.0}"
+WIMBOOT_RELEASE_BASE="https://github.com/ipxe/wimboot/releases/download/${WIMBOOT_VERSION}"
+
+for tool in curl tar; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        echo "Required tool not found in PATH: $tool" >&2
+        exit 1
+    fi
+done
+
+STAGING="$(mktemp -d)"
+trap 'rm -rf "$STAGING"' EXIT
+
+# --- download the official signed iPXE + shim archive -------------------------
+
+echo "==> Downloading iPXE ${IPXE_VERSION} signed netboot archive"
+curl -fsSL -o "$STAGING/ipxeboot.tar.gz" "$IPXE_RELEASE_BASE/ipxeboot.tar.gz"
+mkdir -p "$STAGING/extract"
+tar -xzf "$STAGING/ipxeboot.tar.gz" -C "$STAGING/extract"
+
+# Only the */-sb/ directories contain binaries signed by the iPXE Secure Boot
+# CA — the plain arch directories (x86_64/, arm64/, …) hold UNSIGNED builds
+# that shim rejects with "Verification failed: (0x1A) Security Violation".
+# shim derives the second-stage name from its own filename:
+# ipxe-shimx64.efi loads ipxe.efi, so the signed binary must keep that name.
+X64_IPXE="$(find "$STAGING/extract" -type f -path '*x86_64-sb*' -name 'ipxe.efi' | head -n1)"
+if [[ -z "$X64_IPXE" ]]; then
+    echo "Could not find the SIGNED x86_64-sb/ipxe.efi in ipxeboot.tar.gz — archive layout changed?" >&2
+    echo "Archive contents:" >&2
+    find "$STAGING/extract" -type f >&2
+    exit 1
+fi
+cp "$X64_IPXE" "$STAGING/ipxe.efi"
+
+# Cheap signature sanity check: the signing cert's CN is embedded verbatim in
+# a signed PE. Catches accidentally grabbing an unsigned build.
+if ! grep -aq "iPXE Secure Boot" "$STAGING/ipxe.efi"; then
+    echo "ipxe.efi does not contain an iPXE Secure Boot CA signature — refusing to ship it" >&2
+    exit 1
+fi
+
+ARM64_IPXE="$(find "$STAGING/extract" -type f -path '*arm64-sb*' -name 'ipxe.efi' | head -n1)"
+if [[ -n "$ARM64_IPXE" ]] && grep -aq "iPXE Secure Boot" "$ARM64_IPXE"; then
+    cp "$ARM64_IPXE" "$STAGING/ipxe-arm64.efi"
+else
+    echo "WARNING: no signed ARM64 iPXE binary found in the archive; skipping ARM64 support" >&2
+fi
+
+# The Microsoft-signed shim ships inside the same archive, release-paired with
+# the signing certs used for the iPXE binaries above. Renamed so shim derives
+# "ipxe.efi" as its second-stage filename (ipxe-shimx64.efi -> ipxe.efi).
+X64_SHIM="$(find "$STAGING/extract" -type f -path '*x86_64-sb*' -name 'shimx64.efi' | head -n1)"
+if [[ -z "$X64_SHIM" ]] || ! grep -aq "Microsoft Corporation" "$X64_SHIM"; then
+    echo "Could not find a Microsoft-signed x86_64-sb/shimx64.efi in ipxeboot.tar.gz" >&2
+    find "$STAGING/extract" -type f >&2
+    exit 1
+fi
+cp "$X64_SHIM" "$STAGING/ipxe-shimx64.efi"
+
+ARM64_SHIM="$(find "$STAGING/extract" -type f -path '*arm64-sb*' -name 'shimaa64.efi' | head -n1)"
+if [[ -n "$ARM64_SHIM" ]]; then
+    cp "$ARM64_SHIM" "$STAGING/ipxe-shimaa64.efi"
+fi
+
+# --- download official wimboot -------------------------------------------------
+
+echo "==> Downloading wimboot ${WIMBOOT_VERSION}"
+curl -fsSL -o "$STAGING/wimboot" "$WIMBOOT_RELEASE_BASE/wimboot"
+
+# --- assemble the output set ---------------------------------------------------
+
+echo "==> Assembling $OUT_DIR"
+rm -rf "$OUT_DIR"
+mkdir -p "$OUT_DIR"
+
+cp "$STAGING/ipxe-shimx64.efi"  "$OUT_DIR/"
+if [[ -f "$STAGING/ipxe-shimaa64.efi" ]]; then
+    cp "$STAGING/ipxe-shimaa64.efi" "$OUT_DIR/"
+fi
+cp "$STAGING/ipxe.efi"          "$OUT_DIR/"
+if [[ -f "$STAGING/ipxe-arm64.efi" ]]; then
+    cp "$STAGING/ipxe-arm64.efi" "$OUT_DIR/"
+fi
+cp "$STAGING/wimboot"           "$OUT_DIR/"
+# BIOS clients don't do Secure Boot; reuse the stock undionly.kpxe.
+cp "$BOOTLOADERS_DEFAULT/undionly.kpxe" "$OUT_DIR/"
+
+cat > "$OUT_DIR/manifest.json" <<EOF
+{
+  "name": "secureboot-official",
+  "description": "Zero-enrollment UEFI Secure Boot: release-paired Microsoft-signed shim + official iPXE ${IPXE_VERSION} binaries signed by the iPXE Secure Boot CA. No embedded script — relies on autoexec.ipxe over TFTP (iPXE >= 2.0).",
+  "shim_version": "bundled-${IPXE_VERSION}",
+  "bootfiles": {
+    "bios": "undionly.kpxe",
+    "uefi": "ipxe-shimx64.efi",
+    "arm64": "ipxe-shimaa64.efi"
+  }
+}
+EOF
+
+echo
+echo "Done. Zero-enrollment secureboot set in $OUT_DIR:"
+ls -lh "$OUT_DIR"
+echo
+echo "Verify signatures before deploying (sbsigntool provides sbverify):"
+echo "  sbverify --list $OUT_DIR/ipxe-shimx64.efi   # expect Microsoft UEFI CA"
+echo "  sbverify --list $OUT_DIR/ipxe.efi           # expect iPXE Secure Boot CA"
+echo "  sbverify --list $OUT_DIR/wimboot            # check before relying on Windows boots"
+echo
+echo "This set is not embedded in the bootimus binary (its binaries are not"
+echo "committed). Copy it into the data directory as an on-disk set:"
+echo "  cp -r $OUT_DIR <data_dir>/bootloaders/secureboot-official"
+echo "then select it via the bootloader-sets API/UI. The built-in proxyDHCP"
+echo "advertises the manifest's bootfiles automatically. External DHCP servers"
+echo "must point UEFI clients at ipxe-shimx64.efi themselves."

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+
+# Seed the zero-enrollment Secure Boot bootloader set (baked into the image at
+# build time) into the data volume as an on-disk set, unless one already
+# exists. Delete <data>/bootloaders/secureboot-official to re-seed from a
+# newer image.
+DATA_DIR="${BOOTIMUS_DATA_DIR:-/data}"
+SEED_SRC="/usr/share/bootimus/secureboot-official"
+SEED_DST="$DATA_DIR/bootloaders/secureboot-official"
+
+if [ -d "$SEED_SRC" ] && [ ! -d "$SEED_DST" ]; then
+    mkdir -p "$DATA_DIR/bootloaders"
+    cp -r "$SEED_SRC" "$SEED_DST"
+    echo "Seeded Secure Boot bootloader set into $SEED_DST"
+fi
+
+exec /bootimus "$@"


### PR DESCRIPTION
Hi @garybowers,

I have tried to debug on the Secureboot stuff, and I have gotten Windows to boot completely with the changes in this PR. Some of the stuff probably shouldnt be in a Dockerfile, and shouldnt be in a entrypoint neither due to being able to run the Go-executeable without Docker.

It was just the simplest solution for me to test within my environment and without changing too much in the codebase.

Either way, here is a PR you can take a look at.

Some AI has been used to debug and write code.

Changes I had to make:
- ProxyDHCP didnt seem to actually take the input from the bootloader configuration.
- Secureboot stuff from multiple other repos (iPXE and WIMBOOT)
- rawbcd made my screen always black
- SMB:
-- I had to set some flags for the SMB config to make it run inside Kubernetes and NFS as the underlying share.
-- handlers.go have some changes to the startup sequence on boot when Windows 11 starts up. I got issues with error 53, and also that I didnt have access to the share. AI helped a bit here, and said some flags had to be set. Some fiddling around made it more stable for me.

Regards,
NPetersen