### PR TITLE
disable windows 11 hardware checks and bind the smb server to the same address as the main server

### DIFF
--- a/internal/admin/handlers.go
+++ b/internal/admin/handlers.go
@@ -257,16 +257,17 @@ cmd.exe
 exit /b 1
 :mapped
 
-if not exist Z:\setup.exe (
+set SETUP=Z:\setup.exe
+set SETUP_ARGS=/noreboot
+
+if not exist !SETUP! (
 	echo.
-	echo ERROR: Z:\setup.exe not found on the share.
+	echo ERROR: !SETUP! not found on the share.
 	dir Z:\
 	echo Type 'exit' to reboot.
 	cmd.exe
 	exit /b 1
 )
-
-set SETUP_ARGS=
 
 if exist x:\drivers set SETUP_ARGS=!SETUP_ARGS! /installdrivers x:\drivers
 
@@ -281,8 +282,17 @@ if exist Z:\AutoUnattend.xml (
 
 {{- end }}
 
-echo Starting Windows Setup...
-Z:\setup.exe !SETUP_ARGS!
+echo Starting Windows Setup as !SETUP! !SETUP_ARGS!...
+!SETUP! !SETUP_ARGS!
+
+if !ERRORLEVEL! neq 0 (
+	echo ERROR: Windows Setup failed with exit code !ERRORLEVEL!
+	echo See https://learn.microsoft.com/en-us/windows/deployment/upgrade/log-files
+	echo Dropping to shell for debugging. Try: dir /a X:\$Windows.~BT\Sources\Panther
+	echo Type 'exit' to reboot.
+	cmd.exe
+	exit /b 1
+)
 `))
 
 	var buf bytes.Buffer

--- a/internal/admin/handlers.go
+++ b/internal/admin/handlers.go
@@ -205,6 +205,11 @@ if exist x:\drivers (
 
 wpeinit
 
+echo Disabling Windows 11 hardware checks...
+reg add HKLM\SYSTEM\Setup\LabConfig /v BypassTPMCheck /t REG_DWORD /d 1
+reg add HKLM\SYSTEM\Setup\LabConfig /v BypassSecureBootCheck /t REG_DWORD /d 1
+reg add HKLM\SYSTEM\Setup\LabConfig /v BypassRAMCheck /t REG_DWORD /d 1
+
 rem Windows 11 24H2+ WinPE ships with insecure guest auth disabled and SMB
 rem signing required; guest sessions cannot sign, so mapping the read-only
 rem guest share fails with access denied. Re-enable guest SMB for this

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -520,7 +520,7 @@ func (s *Server) Start() error {
 	}
 
 	if s.config.WindowsSMBEnabled {
-		mgr := smb.NewManager(s.config.DataDir, s.config.WindowsSMBPort)
+		mgr := smb.NewManager(s.config.DataDir, s.config.ServerAddr, s.config.WindowsSMBPort)
 		s.preloadSMBShares(mgr)
 		if err := mgr.Start(); err != nil {
 			log.Printf("Windows SMB: requested but could not start: %v - feature disabled for this run", err)

--- a/internal/smb/manager.go
+++ b/internal/smb/manager.go
@@ -1,6 +1,7 @@
 package smb
 
 import (
+	"bytes"
 	"fmt"
 	"log"
 	"os"
@@ -8,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"text/template"
 )
 
 type Manager struct {
@@ -153,56 +155,67 @@ func (m *Manager) writeConfig() error {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	dir := m.smbDir()
-	var sb strings.Builder
-	fmt.Fprintf(&sb, `[global]
-   workgroup = WORKGROUP
-   server role = standalone server
-   log level = 1
-   log file = %s/log/smbd.log
-   smb ports = %d
-   server min protocol = SMB2
-   map to guest = bad user
-   guest account = nobody
-   load printers = no
-   disable spoolss = yes
-   # Install clients (WinPE) reboot mid-session and reconnect with the same
-   # IP. Without these, smbd hangs onto the prior tree connect/oplocks and
-   # the next net use fails. Locks aren't meaningful for a read-only share.
-   oplocks = no
-   kernel oplocks = no
-   level2 oplocks = no
-   strict locking = no
-   deadtime = 1
-   # Windows sends VC=0 on session setup after a reboot. Without this, smbd
-   # keeps the prior session from the same client IP alive and refuses the
-   # new one. This is the specific fix for "net use fails after VM reboot".
-   reset on zero vc = yes
-   lock directory = %s/locks
-   state directory = %s/state
-   cache directory = %s/cache
-   pid directory = %s/pid
-   ncalrpc dir = %s/ncalrpc
-   private dir = %s/private
-   usershare path = %s/usershares
-   acl allow execute always = yes
+	configTemplate := template.Must(template.New("config").Parse(`[global]
+workgroup = WORKGROUP
+server role = standalone server
+log level = 1
+log file = {{ .Dir }}/log/smbd.log
+smb ports = {{ .Port }}
+server min protocol = SMB2
+map to guest = bad user
+guest account = nobody
+load printers = no
+disable spoolss = yes
+# Install clients (WinPE) reboot mid-session and reconnect with the same
+# IP. Without these, smbd hangs onto the prior tree connect/oplocks and
+# the next net use fails. Locks aren't meaningful for a read-only share.
+oplocks = no
+kernel oplocks = no
+level2 oplocks = no
+strict locking = no
+deadtime = 1
+# Windows sends VC=0 on session setup after a reboot. Without this, smbd
+# keeps the prior session from the same client IP alive and refuses the
+# new one. This is the specific fix for "net use fails after VM reboot".
+reset on zero vc = yes
+lock directory = {{ .Dir }}/locks
+state directory = {{ .Dir }}/state
+cache directory = {{ .Dir }}/cache
+pid directory = {{ .Dir }}/pid
+ncalrpc dir = {{ .Dir }}/ncalrpc
+private dir = {{ .Dir }}/private
+usershare path = {{ .Dir }}/usershares
+acl allow execute always = yes
 
-`, dir, m.port, dir, dir, dir, dir, dir, dir, dir)
+{{- range $name, $path := .Shares }}
 
-	for name, path := range m.shares {
-		fmt.Fprintf(&sb, `[%s]
-   path = %s
-   read only = yes
-   guest ok = yes
-   # Guest maps to "nobody" (uid 65534), which NFS-backed data dirs commonly
-   # reject (root squash / export rules only trust specific UIDs). The
-   # bootimus process already reads these files as root, so let smbd do the
-   # same. Shares are read-only, so this only widens reads.
-   force user = root
-   browseable = yes
+[{{ $name }}]
+path = {{ $path }}
+read only = yes
+guest ok = yes
+# Guest maps to "nobody" (uid 65534), which NFS-backed data dirs commonly
+# reject (root squash / export rules only trust specific UIDs). The
+# bootimus process already reads these files as root, so let smbd do the
+# same. Shares are read-only, so this only widens reads.
+force user = root
+browseable = yes
 
-`, name, path)
+{{- end }}
+`))
+
+	var buf bytes.Buffer
+	err := configTemplate.Execute(&buf, &struct {
+		Dir    string
+		Port   int
+		Shares map[string]string
+	}{
+		Dir:    m.smbDir(),
+		Port:   m.port,
+		Shares: m.shares,
+	})
+	if err != nil {
+		return err
 	}
 
-	return os.WriteFile(m.configPath(), []byte(sb.String()), 0644)
+	return os.WriteFile(m.configPath(), buf.Bytes(), 0644)
 }

--- a/internal/smb/manager.go
+++ b/internal/smb/manager.go
@@ -169,6 +169,7 @@ server min protocol = SMB2
 map to guest = bad user
 guest account = nobody
 load printers = no
+disable netbios = yes
 disable spoolss = yes
 # Install clients (WinPE) reboot mid-session and reconnect with the same
 # IP. Without these, smbd hangs onto the prior tree connect/oplocks and

--- a/internal/smb/manager.go
+++ b/internal/smb/manager.go
@@ -14,6 +14,7 @@ import (
 
 type Manager struct {
 	dataDir string
+	addr    string
 	port    int
 
 	mu     sync.RWMutex
@@ -22,9 +23,10 @@ type Manager struct {
 	cmd *exec.Cmd
 }
 
-func NewManager(dataDir string, port int) *Manager {
+func NewManager(dataDir string, addr string, port int) *Manager {
 	return &Manager{
 		dataDir: dataDir,
+		addr:    addr,
 		port:    port,
 		shares:  make(map[string]string),
 	}
@@ -160,6 +162,8 @@ workgroup = WORKGROUP
 server role = standalone server
 log level = 1
 log file = {{ .Dir }}/log/smbd.log
+bind interfaces only = yes
+interfaces = {{ .Addr }}
 smb ports = {{ .Port }}
 server min protocol = SMB2
 map to guest = bad user
@@ -206,10 +210,12 @@ browseable = yes
 	var buf bytes.Buffer
 	err := configTemplate.Execute(&buf, &struct {
 		Dir    string
+		Addr   string
 		Port   int
 		Shares map[string]string
 	}{
 		Dir:    m.smbDir(),
+		Addr:   m.addr,
 		Port:   m.port,
 		Shares: m.shares,
 	})


### PR DESCRIPTION
* disable windows 11 hardware checks
* drop into the shell when the windows setup fails
    * without this, the machine just reboots without showing any clue
* bind the smb server to the same address as the main server
* disable the deprecated smb netbios
* use a go template to generate the smb configuration