### PR TITLE
Fix one-time boot for grouped images

### DIFF
--- a/internal/server/menu.go
+++ b/internal/server/menu.go
@@ -91,12 +91,28 @@ func (mb *MenuBuilder) Build() string {
 	var sb strings.Builder
 
 	sb.WriteString("#!ipxe\n\n")
-	sb.WriteString(mb.buildMainMenu())
+	if mb.hasEnabledImage(mb.nextBootImageID) {
+		sb.WriteString(fmt.Sprintf("goto iso%d\n\n", mb.nextBootImageID))
+	} else {
+		sb.WriteString(mb.buildMainMenu())
+	}
 	sb.WriteString(mb.buildGroupMenus())
 	sb.WriteString(mb.buildImageBootSections())
 	sb.WriteString(mb.buildFooter())
 
 	return sb.String()
+}
+
+func (mb *MenuBuilder) hasEnabledImage(id uint) bool {
+	if id == 0 {
+		return false
+	}
+	for i := range mb.images {
+		if mb.images[i].ID == id && mb.images[i].Enabled {
+			return true
+		}
+	}
+	return false
 }
 
 func (mb *MenuBuilder) menuTimeoutMs() int {

--- a/internal/server/menu_test.go
+++ b/internal/server/menu_test.go
@@ -16,6 +16,44 @@ func testMenuBuilder(types map[uint]string) *MenuBuilder {
 	}
 }
 
+func TestBuildNextBootBypassesMenuForGroupedImage(t *testing.T) {
+	groupID := uint(3)
+	mb := testMenuBuilder(map[uint]string{7: "kickstart"})
+	mb.nextBootImageID = 7
+	mb.images = []models.Image{
+		{
+			ID:         7,
+			Name:       "AlmaLinux",
+			Filename:   "almalinux.iso",
+			Enabled:    true,
+			BootMethod: "kernel",
+			Distro:     "alma",
+			GroupID:    &groupID,
+		},
+	}
+
+	out := mb.Build()
+	if !strings.HasPrefix(out, "#!ipxe\n\ngoto iso7\n\n") {
+		t.Fatalf("expected next boot to jump directly to the image, got:\n%s", out)
+	}
+	if !strings.Contains(out, ":iso7\n") {
+		t.Fatalf("expected next boot image section to be emitted, got:\n%s", out)
+	}
+	if strings.Contains(out, ":start\nmenu ") {
+		t.Fatalf("expected next boot to bypass the interactive menu, got:\n%s", out)
+	}
+}
+
+func TestBuildMissingNextBootFallsBackToMenu(t *testing.T) {
+	mb := testMenuBuilder(nil)
+	mb.nextBootImageID = 99
+
+	out := mb.Build()
+	if !strings.Contains(out, ":start\nmenu ") {
+		t.Fatalf("expected an unavailable next boot image to fall back to the menu, got:\n%s", out)
+	}
+}
+
 func TestBuildKernelBootSectionAutoInstallParams(t *testing.T) {
 	img := &models.Image{
 		ID:         7,


### PR DESCRIPTION
## Summary

- bypass the interactive menu when a valid enabled one-time boot image is set
- retain the normal menu fallback when the requested image is missing or disabled
- add regression coverage for grouped next-boot images and the fallback path

## Why

Grouped images are rendered as labels inside their group submenu, but the existing implementation selects the one-time image label as the default on the top-level menu. Since that label is not present at the top level, iPXE selects a different valid top-level entry instead of booting the requested image.

Jumping directly to the image's boot section makes one-time boot deterministic and avoids requiring menu interaction, which is especially important for unattended provisioning.

Fixes #113

## Validation

- `go test ./...`
- validated with a grouped AlmaLinux kernel-boot image on a physical UEFI PXE client
- confirmed the patched menu immediately requested the configured image's kernel and initrd
